### PR TITLE
Make Random only use Super Allies/Soviets

### DIFF
--- a/rabhc/rules/world.yaml
+++ b/rabhc/rules/world.yaml
@@ -59,7 +59,7 @@
 	Faction@random:
 		Name: Any
 		InternalName: Random
-		RandomFactionMembers: RandomAllies, RandomSoviet
+		RandomFactionMembers: sallies, ssoviet
 		Side: Random
 		Description: A random country.
 	Faction@randomallies:


### PR DESCRIPTION
This changes Random from using RandomAllies (england, france, germany) and RandomSoviet (russia, ukraine) to only use ssoviet and sallies.

I didn't increase the Version number in this PR.

One test with 12 AI's in Singleplayer gave me 7 Super Allies and 5 Super Soviet. So I'd say this works.
Random Ally and Random Soviet still have the same behaviour.