### PR TITLE
Fix error in #2

### DIFF
--- a/rabhc/maps/allies-01/map.yaml
+++ b/rabhc/maps/allies-01/map.yaml
@@ -446,6 +446,6 @@ Actors:
 		Location: 68,76
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/allies-02/map.yaml
+++ b/rabhc/maps/allies-02/map.yaml
@@ -672,6 +672,6 @@ Actors:
 		Location: 89,51
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/allies-03a/map.yaml
+++ b/rabhc/maps/allies-03a/map.yaml
@@ -1307,6 +1307,6 @@ Actors:
 		Location: 59,72
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/allies-03b/map.yaml
+++ b/rabhc/maps/allies-03b/map.yaml
@@ -1202,6 +1202,6 @@ Actors:
 		Location: 83,94
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/allies-04/map.yaml
+++ b/rabhc/maps/allies-04/map.yaml
@@ -535,5 +535,5 @@ Actors:
 		Location: 88,52
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 

--- a/rabhc/maps/allies-05a/map.yaml
+++ b/rabhc/maps/allies-05a/map.yaml
@@ -1561,7 +1561,7 @@ Actors:
 		Owner: Neutral
 		Location: 63,63
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml
 

--- a/rabhc/maps/allies-06a/map.yaml
+++ b/rabhc/maps/allies-06a/map.yaml
@@ -637,6 +637,6 @@ Actors:
 		Owner: Neutral
 		Location: 73,90
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/evacuation/map.yaml
+++ b/rabhc/maps/evacuation/map.yaml
@@ -1754,4 +1754,4 @@ Actors:
 		Owner: Soviets
 		ScriptTags: TownAttacker
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/exodus/map.yaml
+++ b/rabhc/maps/exodus/map.yaml
@@ -1426,4 +1426,4 @@ Actors:
 		Owner: Soviets
 		Location: 130, 45
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/infiltration/map.yaml
+++ b/rabhc/maps/infiltration/map.yaml
@@ -1785,4 +1785,4 @@ Actors:
 		Owner: Soviets
 		Location: 43,50
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/intervention/map.yaml
+++ b/rabhc/maps/intervention/map.yaml
@@ -2199,6 +2199,6 @@ Actors:
 		Location: 129,57
 		Owner: Soviets
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/monster-tank-madness/map.yaml
+++ b/rabhc/maps/monster-tank-madness/map.yaml
@@ -2087,7 +2087,7 @@ Actors:
 		Location: 65,78
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml
 

--- a/rabhc/maps/soviet-01/map.yaml
+++ b/rabhc/maps/soviet-01/map.yaml
@@ -585,4 +585,4 @@ Actors:
 		Location: 51,84
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-02a/map.yaml
+++ b/rabhc/maps/soviet-02a/map.yaml
@@ -564,4 +564,4 @@ Actors:
 		Owner: Germany
 		SubCell: 2
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-02b/map.yaml
+++ b/rabhc/maps/soviet-02b/map.yaml
@@ -488,6 +488,6 @@ Actors:
 		Location: 67,75
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/soviet-03/map.yaml
+++ b/rabhc/maps/soviet-03/map.yaml
@@ -1168,7 +1168,7 @@ Actors:
 		Location: 47,50
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml
 

--- a/rabhc/maps/soviet-04a/map.yaml
+++ b/rabhc/maps/soviet-04a/map.yaml
@@ -617,4 +617,4 @@ Actors:
 		Location: 84,83
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-04b/map.yaml
+++ b/rabhc/maps/soviet-04b/map.yaml
@@ -645,4 +645,4 @@ Actors:
 		Location: 33,88
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-05/map.yaml
+++ b/rabhc/maps/soviet-05/map.yaml
@@ -596,4 +596,4 @@ Actors:
 		Location: 21,80
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-06a/map.yaml
+++ b/rabhc/maps/soviet-06a/map.yaml
@@ -827,4 +827,4 @@ Actors:
 		Location: 22,15
 		Owner: Greece
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-06b/map.yaml
+++ b/rabhc/maps/soviet-06b/map.yaml
@@ -519,4 +519,4 @@ Actors:
 		Location: 67,41
 		Owner: Greece
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/soviet-07/map.yaml
+++ b/rabhc/maps/soviet-07/map.yaml
@@ -790,6 +790,6 @@ Actors:
 		Owner: Neutral
 		Location: 45,52
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/maps/survival01/map.yaml
+++ b/rabhc/maps/survival01/map.yaml
@@ -1193,4 +1193,4 @@ Actors:
 		Location: 58,61
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml

--- a/rabhc/maps/survival02/map.yaml
+++ b/rabhc/maps/survival02/map.yaml
@@ -1006,6 +1006,6 @@ Actors:
 		Location: 39,37
 		Owner: Neutral
 
-Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, rules.yaml
+Rules: rabhc|rules/campaign-rules.yaml, rabhc|rules/campaign-tooltips.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/rabhc/mod.yaml
+++ b/rabhc/mod.yaml
@@ -13,7 +13,7 @@ Packages:
 	~^Content/ra/v2/cnc
 	~^Content/ra/v2/movies
 	.
-	$ra: ra
+	$rabhc: rabhc
 	./mods/common: common
 	~main.mix
 	~conquer.mix
@@ -31,51 +31,51 @@ Packages:
 	~expand2.mix
 	~hires1.mix
 	~desert.mix
-	ra|bits
-	ra|bits/desert
-	ra|uibits
+	rabhc|bits
+	rabhc|bits/desert
+	rabhc|uibits
 
 MapFolders:
-	ra|maps: System
-	~^maps/ra/playtest-20170304: User
+	rabhc|maps: System
+	~^maps/rabhc/playtest-20170304: User
 
 Rules:
-	ra|rules/misc.yaml
-	ra|rules/ai.yaml
-	ra|rules/player.yaml
-	ra|rules/palettes.yaml
-	ra|rules/world.yaml
-	ra|rules/defaults.yaml
-	ra|rules/vehicles.yaml
-	ra|rules/husks.yaml
-	ra|rules/structures.yaml
-	ra|rules/infantry.yaml
-	ra|rules/civilian.yaml
-	ra|rules/decoration.yaml
-	ra|rules/aircraft.yaml
-	ra|rules/ships.yaml
-	ra|rules/fakes.yaml
+	rabhc|rules/misc.yaml
+	rabhc|rules/ai.yaml
+	rabhc|rules/player.yaml
+	rabhc|rules/palettes.yaml
+	rabhc|rules/world.yaml
+	rabhc|rules/defaults.yaml
+	rabhc|rules/vehicles.yaml
+	rabhc|rules/husks.yaml
+	rabhc|rules/structures.yaml
+	rabhc|rules/infantry.yaml
+	rabhc|rules/civilian.yaml
+	rabhc|rules/decoration.yaml
+	rabhc|rules/aircraft.yaml
+	rabhc|rules/ships.yaml
+	rabhc|rules/fakes.yaml
 
 Sequences:
-	ra|sequences/ships.yaml
-	ra|sequences/vehicles.yaml
-	ra|sequences/structures.yaml
-	ra|sequences/infantry.yaml
-	ra|sequences/aircraft.yaml
-	ra|sequences/misc.yaml
-	ra|sequences/decorations.yaml
+	rabhc|sequences/ships.yaml
+	rabhc|sequences/vehicles.yaml
+	rabhc|sequences/structures.yaml
+	rabhc|sequences/infantry.yaml
+	rabhc|sequences/aircraft.yaml
+	rabhc|sequences/misc.yaml
+	rabhc|sequences/decorations.yaml
 
 TileSets:
-	ra|tilesets/snow.yaml
-	ra|tilesets/interior.yaml
-	ra|tilesets/temperat.yaml
-	ra|tilesets/desert.yaml
+	rabhc|tilesets/snow.yaml
+	rabhc|tilesets/interior.yaml
+	rabhc|tilesets/temperat.yaml
+	rabhc|tilesets/desert.yaml
 
 Cursors:
-	ra|cursors.yaml
+	rabhc|cursors.yaml
 
 Chrome:
-	ra|chrome.yaml
+	rabhc|chrome.yaml
 
 Assemblies:
 	common|OpenRA.Mods.Common.dll
@@ -91,7 +91,7 @@ ChromeLayout:
 	common|chrome/ingame-infoobjectives.yaml
 	common|chrome/ingame-infostats.yaml
 	common|chrome/ingame-menu.yaml
-	ra|chrome/ingame-observer.yaml
+	rabhc|chrome/ingame-observer.yaml
 	common|chrome/ingame-observerstats.yaml
 	common|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml
@@ -124,27 +124,27 @@ ChromeLayout:
 	common|chrome/editor.yaml
 
 Weapons:
-	ra|weapons/explosions.yaml
-	ra|weapons/ballistics.yaml
-	ra|weapons/missiles.yaml
-	ra|weapons/other.yaml
-	ra|weapons/smallcaliber.yaml
-	ra|weapons/superweapons.yaml
+	rabhc|weapons/explosions.yaml
+	rabhc|weapons/ballistics.yaml
+	rabhc|weapons/missiles.yaml
+	rabhc|weapons/other.yaml
+	rabhc|weapons/smallcaliber.yaml
+	rabhc|weapons/superweapons.yaml
 	
 Voices:
-	ra|audio/voices.yaml
+	rabhc|audio/voices.yaml
 
 Notifications:
-	ra|audio/notifications.yaml
+	rabhc|audio/notifications.yaml
 
 Music:
-	ra|audio/music.yaml
+	rabhc|audio/music.yaml
 
 Translations:
-	ra|languages/english.yaml
+	rabhc|languages/english.yaml
 
 LoadScreen: LogoStripeLoadScreen
-	Image: ra|uibits/loadscreen.png
+	Image: rabhc|uibits/loadscreen.png
 	Text: Filling Crates..., Charging Capacitors..., Reticulating Splines..., Planting Trees..., Building Bridges..., Aging Empires..., Compiling EVA..., Constructing Pylons..., Activating Skynet..., Splitting Atoms...
 
 ServerTraits:
@@ -155,7 +155,7 @@ ServerTraits:
 
 ChromeMetrics:
 	common|metrics.yaml
-	ra|metrics.yaml
+	rabhc|metrics.yaml
 
 Fonts:
 	Regular:
@@ -165,7 +165,7 @@ Fonts:
 		Font: common|FreeSansBold.ttf
 		Size:14
 	Title:
-		Font: ra|ZoodRangmah.ttf
+		Font: rabhc|ZoodRangmah.ttf
 		Size:48
 	MediumBold:
 		Font: common|FreeSansBold.ttf
@@ -184,13 +184,13 @@ Fonts:
 		Size:10
 
 Missions:
-	ra|missions.yaml
+	rabhc|missions.yaml
 
 MapGrid:
 	TileSize: 24,24
 	Type: Rectangular
 
-SupportsMapsFrom: ra
+SupportsMapsFrom: ra, rabhc
 
 SoundFormats: Aud, Wav
 
@@ -260,12 +260,12 @@ ModContent:
 			TestFiles: ^Content/ra/v2/expand/await.aud, ^Content/ra/v2/expand/bog.aud, ^Content/ra/v2/expand/float_v2.aud, ^Content/ra/v2/expand/gloom.aud, ^Content/ra/v2/expand/grndwire.aud, ^Content/ra/v2/expand/rpt.aud, ^Content/ra/v2/expand/search.aud, ^Content/ra/v2/expand/traction.aud, ^Content/ra/v2/expand/wastelnd.aud
 			Sources: aftermath, aftermath-linux, ra-origin
 	Downloads:
-		ra|installer/downloads.yaml
+		rabhc|installer/downloads.yaml
 	Sources:
-		ra|installer/aftermath.yaml
-		ra|installer/allies95.yaml
-		ra|installer/cnc95.yaml
-		ra|installer/counterstrike.yaml
-		ra|installer/firstdecade.yaml
-		ra|installer/origin.yaml
-		ra|installer/soviet95.yaml
+		rabhc|installer/aftermath.yaml
+		rabhc|installer/allies95.yaml
+		rabhc|installer/cnc95.yaml
+		rabhc|installer/counterstrike.yaml
+		rabhc|installer/firstdecade.yaml
+		rabhc|installer/origin.yaml
+		rabhc|installer/soviet95.yaml


### PR DESCRIPTION
Just changing the Name (from #2) actually wasn't enough. The file References were still pointing to the ra folder so it would load the rules from ra and not from rabhc.
In the future I should remember to test my changes before doing a PR ^^

The Maps still say they [ require `ra` ](https://github.com/dedmen/openrabhc/blob/0a6f4b8d7b48f6cd751cc836de1e46b2c022e70b/rabhc/maps/allies-01/map.yaml#L3) but they still Load with only `rabhc` available which is because [this](https://github.com/blackhandcommando/openrabhc/pull/6/files#diff-4dcbeeb771ed04d364f8e75d284cf39bR193) I think.