### PR TITLE
Superweapon Nuke only usable once

### DIFF
--- a/rabhc/mod.yaml
+++ b/rabhc/mod.yaml
@@ -1,7 +1,7 @@
 Metadata:
 	Title: Red Alert (BlackHandCommando Edition)
 	Description: In a world where Hitler was assassinated and the Third Reich never\nexisted, the Soviet Union seeks power over all of Europe.  Allied\nagainst this Evil Empire, the free world faces a Cold War turned hot.\n\nRed Alert fuses the quick and fun gameplay of the original\nC&C: Red Alert, with balance improvements and new gameplay\nfeatures inspired by modern RTS games.
-	Version: playtest-20170304_bhc1
+	Version: playtest-20170304_bhc2
 	Author: the OpenRA Developers and modified by BlackHandCommando
 
 RequiresMods:

--- a/rabhc/rules/structures.yaml
+++ b/rabhc/rules/structures.yaml
@@ -20,6 +20,7 @@ MSLO:
 	RevealsShroud:
 		Range: 5c0
 	NukePower:
+		OneShot: yes
 		Cursor: nuke
 		Icon: abomb
 		ChargeTime: 540


### PR DESCRIPTION
Makes the Nuke ability oneshot like the GPS Ability.
Is not really needed. But Probably easier instead of telling everyone to only use it once.

This also contains the next version number (`bhc2`).